### PR TITLE
Bugfix: Residues with listing difference style "none"

### DIFF
--- a/sources/adjustments/Adjust_Listings.ts
+++ b/sources/adjustments/Adjust_Listings.ts
@@ -481,7 +481,8 @@ module Adjust_Listings {
                             Util.buildHTML('div', {
                                 class: 'f_12px',
                                 style: {
-                                    'color': priceDiff < 0 ? GlobalConstants.COLOR_GOOD : GlobalConstants.COLOR_BAD
+                                    'color': priceDiff < 0 ? GlobalConstants.COLOR_GOOD : GlobalConstants.COLOR_BAD,
+                                    'display': (listingStyle == ExtensionSettings.ListingDifferenceStyle.NONE) ? 'none' : 'block'
                                 },
                                 attributes: {
                                     'title': priceDiffEx


### PR DESCRIPTION
### The issue
When selecting "none" as option for the listing difference style, BuffUtility still produced a residue in the form of an upward or downward arrow.
The corresponding setting:
![Screenshot_469](https://github.com/PenguiniVogel/BuffUtility/assets/21990230/92a5ec0c-a76f-4cb8-ba60-17514de0efa9)
And the output with that selected setting:
![Screenshot_467](https://github.com/PenguiniVogel/BuffUtility/assets/21990230/e219cdb1-a453-4580-9f8c-3d5d19d17906)

### The fix
With this bugfix, this arrow has now been removed and the price column looks just like the original version by Buff:
![Screenshot_468](https://github.com/PenguiniVogel/BuffUtility/assets/21990230/c5538366-6c7e-4395-968d-07944275df49)

If an option different than "none" is selected, nothing changes with this fix.
